### PR TITLE
Remove redundant slash in artifactURL

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -61,7 +61,7 @@ class Bot
     constructor : (@env) ->
 
     artifactUrl : (artifactPath) ->
-        "#{@env.buildUrl}/artifacts/0/#{@env.home}/#{@env.repo}/#{artifactPath}"
+        "#{@env.buildUrl}/artifacts/0#{@env.home}/#{@env.repo}/#{artifactPath}"
 
     artifactLink : (artifactPath, text) ->
         "<a href='#{@artifactUrl(artifactPath)}' target='_blank'>#{text}</a>"


### PR DESCRIPTION
`env.home` already starts with a `/` because it's an absolute file path.

Currently it's producing urls like: `https://circleci.com/gh/user/project/999/artifacts/0//home/ubuntu/proj/screenshots/home.png`