### PR TITLE
update artifact url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ class Bot {
         const prNumber = basename(process.env.CIRCLE_PULL_REQUEST || process.env.CI_PULL_REQUEST || "");
 
         const env: IEnvironment = {
-            buildUrl: process.env.CIRCLE_BUILD_URL,
+            buildUrl: "https://output.circle-artifacts.com/output/job/" + process.env.CIRCLE_WORKFLOW_JOB_ID,
             commitMessage: exec('git --no-pager log --pretty=format:"%s" -1').replace(/\\"/g, '\\\\"'),
             githubDomain,
             prNumber,


### PR DESCRIPTION
Artifact URL is not working any more, not sure when CircleCI changed the specification but we need to use `CIRCLE_WORKFLOW_JOB_ID`.

https://support.circleci.com/hc/en-us/articles/5034956515355-How-to-Programmatically-Construct-the-URLs-for-Artifacts